### PR TITLE
Add tests for data utilities

### DIFF
--- a/tests/data/test_analyze_token_lengths.py
+++ b/tests/data/test_analyze_token_lengths.py
@@ -1,0 +1,22 @@
+import sys
+import importlib
+import types
+
+
+def test_analyze_token_lengths(monkeypatch, capsys):
+    dummy_data = [
+        {'input_ids': [1, 2, 3, 4]},
+        {'input_ids': [5, 6]}
+    ]
+    dummy_datasets = types.SimpleNamespace(load_from_disk=lambda path: dummy_data)
+    dummy_transformers = types.SimpleNamespace(
+        BertTokenizerFast=types.SimpleNamespace(from_pretrained=lambda name: None)
+    )
+    monkeypatch.setitem(sys.modules, 'datasets', dummy_datasets)
+    monkeypatch.setitem(sys.modules, 'transformers', dummy_transformers)
+    mod = importlib.import_module('llm_utils.data.analyze_token_lengths')
+    lengths = mod.analyze_token_lengths('ignored')
+    captured = capsys.readouterr()
+    assert lengths == [4, 2]
+    assert 'Max tokens: 4' in captured.out
+    assert 'Min tokens: 2' in captured.out

--- a/tests/data/test_intersect_dataset.py
+++ b/tests/data/test_intersect_dataset.py
@@ -1,0 +1,27 @@
+import argparse
+import importlib
+import json
+
+
+def test_load_texts(tmp_path):
+    p = tmp_path / 'data.jsonl'
+    p.write_text('{"text": "A"}\n{"text": "B"}\n{"text": "A"}\n', encoding='utf-8')
+    mod = importlib.import_module('llm_utils.data.intersect_dataset')
+    result = mod.load_texts(p)
+    assert result == {'A', 'B'}
+
+
+def test_intersect_dataset_main(tmp_path, monkeypatch, capsys):
+    file1 = tmp_path / 'f1.jsonl'
+    file2 = tmp_path / 'f2.jsonl'
+    out = tmp_path / 'out.jsonl'
+    file1.write_text('{"text": "A"}\n{"text": "B"}\n', encoding='utf-8')
+    file2.write_text('{"text": "B"}\n{"text": "C"}\n', encoding='utf-8')
+    args = argparse.Namespace(file1=file1, file2=file2, output=out)
+    mod = importlib.import_module('llm_utils.data.intersect_dataset')
+    monkeypatch.setattr(argparse.ArgumentParser, 'parse_args', lambda self: args)
+    mod.main()
+    captured = capsys.readouterr()
+    assert 'overlapping text entries' in captured.out
+    saved = out.read_text().strip()
+    assert json.loads(saved)['text'] == 'B'

--- a/tests/data/test_semantic_sample.py
+++ b/tests/data/test_semantic_sample.py
@@ -1,0 +1,49 @@
+import sys
+import importlib
+import types
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def semantic_sample_module(monkeypatch):
+    dummy_torch = types.SimpleNamespace(
+        backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: False)),
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+        device=lambda name: name,
+        set_default_device=lambda dev: None,
+        float16='float16'
+    )
+    dummy_st = types.SimpleNamespace(SentenceTransformer=lambda model: None)
+    dummy_tqdm = types.SimpleNamespace(tqdm=lambda x, **k: x)
+    dummy_sklearn_decomp = types.SimpleNamespace(PCA=lambda *a, **k: None)
+    dummy_sklearn = types.ModuleType('sklearn')
+    dummy_sklearn.decomposition = dummy_sklearn_decomp
+    monkeypatch.setitem(sys.modules, 'torch', dummy_torch)
+    monkeypatch.setitem(sys.modules, 'sentence_transformers', dummy_st)
+    monkeypatch.setitem(sys.modules, 'tqdm', dummy_tqdm)
+    monkeypatch.setitem(sys.modules, 'sklearn', dummy_sklearn)
+    monkeypatch.setitem(sys.modules, 'sklearn.decomposition', dummy_sklearn_decomp)
+    mod = importlib.import_module('llm_utils.data.semantic_sample')
+    return mod
+
+
+def test_fingerprint(semantic_sample_module):
+    mod = semantic_sample_module
+    vec = np.array([1, -2, 3])
+    assert mod.fingerprint(vec) == 5
+
+
+def test_holdout_split(semantic_sample_module):
+    mod = semantic_sample_module
+    rows = [
+        ('t1', '', 'A'),
+        ('t2', '', 'A'),
+        ('t3', '', 'B'),
+        ('t4', '', 'B'),
+    ]
+    main, holdout = mod.holdout_split(rows, 0.5)
+    assert len(main) == 2
+    assert len(holdout) == 2
+    all_rows = sorted(main + holdout)
+    assert sorted(rows) == all_rows


### PR DESCRIPTION
## Summary
- add new data utility tests
- stub heavy dependencies like transformers and torch for import
- split each utility test into its own module

## Testing
- `pytest -q tests/data/test_analyze_token_lengths.py tests/data/test_intersect_dataset.py tests/data/test_semantic_sample.py tests/test_cue_parser.py tests/test_llm_parsers.py tests/interfacing/test_llm_request.py`

------
https://chatgpt.com/codex/tasks/task_e_686c636b13288331ab256f862693052b