### PR TITLE
Add MockLLMClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # llm-utils
 Training and interface scripts for llms that are general purpose
+
+## MockLLMClient
+
+`MockLLMClient` is a lightweight testing client that returns predefined
+responses instead of contacting a real model. It can be initialised with a list
+of records or a path to a JSON file:
+
+```python
+from llm_utils.interfacing import MockLLMClient
+
+records = [
+    {
+        "model": "qwen:14b",
+        "system_prompt": "You are a helpful and concise assistant.",
+        "user_prompt": "Hello",
+        "temperature": 0.7,
+        "max_tokens": 1024,
+        "repetition_penalty": 1.1,
+        "response": "Hi there!"
+    }
+]
+
+client = MockLLMClient(records)
+print(client.chat("Hello"))  # -> "Hi there!"
+```
+
+Every field used in a request must match a record; otherwise an
+`LLMRequestMismatchError` is raised.

--- a/llm_utils/interfacing/__init__.py
+++ b/llm_utils/interfacing/__init__.py
@@ -1,0 +1,10 @@
+from .base_client import BaseLLMClient
+from .llm_request import LLMClient
+from .mock_llm_client import MockLLMClient, LLMRequestMismatchError
+
+__all__ = [
+    "BaseLLMClient",
+    "LLMClient",
+    "MockLLMClient",
+    "LLMRequestMismatchError",
+]

--- a/llm_utils/interfacing/base_client.py
+++ b/llm_utils/interfacing/base_client.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseLLMClient(ABC):
+    """Abstract interface for language model clients."""
+
+    def __init__(self, model: str | None = None, base_url: str | None = None,
+                 timeout: int = 60, system_prompt: str | None = None,
+                 temperature: float = 0.7, max_tokens: int = 1024,
+                 repetition_penalty: float = 1.1):
+        self.model = model
+        self.base_url = base_url
+        self.timeout = timeout
+        self.system_prompt = system_prompt or "You are a helpful and concise assistant."
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.repetition_penalty = repetition_penalty
+
+    @abstractmethod
+    def chat(self, prompt: str, temperature: float | None = None,
+             max_tokens: int | None = None,
+             repetition_penalty: float | None = None, stream: bool = False) -> str:
+        """Return the LLM response for the given prompt."""
+        raise NotImplementedError

--- a/llm_utils/interfacing/llm_request.py
+++ b/llm_utils/interfacing/llm_request.py
@@ -1,6 +1,8 @@
 import httpx
 import os
 
+from .base_client import BaseLLMClient
+
 class LLMError(Exception):
     """Base exception for LLMClient errors."""
 
@@ -25,15 +27,16 @@ class LLMUnexpectedResponseError(LLMError):
 DEFAULT_MODEL = os.getenv("LLM_MODEL", "qwen:14b")
 DEFAULT_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:1234/v1")
 
-class LLMClient:
+class LLMClient(BaseLLMClient):
     def __init__(self, model=None, base_url=None, timeout=60, system_prompt=None, temperature=0.7, max_tokens=1024, repetition_penalty=1.1, client=None):
-        self.model = model or os.getenv("LLM_MODEL", "qwen:14b")
-        self.base_url = base_url or os.getenv("LLM_BASE_URL", "http://localhost:1234/v1")
-        self.timeout = timeout
-        self.system_prompt = system_prompt or os.getenv("LLM_SYSTEM_PROMPT", "You are a helpful and concise assistant.")
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.repetition_penalty = repetition_penalty
+        super().__init__(model=model or os.getenv("LLM_MODEL", "qwen:14b"),
+                         base_url=base_url or os.getenv("LLM_BASE_URL", "http://localhost:1234/v1"),
+                         timeout=timeout,
+                         system_prompt=system_prompt or os.getenv("LLM_SYSTEM_PROMPT", "You are a helpful and concise assistant."),
+                         temperature=temperature,
+                         max_tokens=max_tokens,
+                         repetition_penalty=repetition_penalty)
+
         self.client = client or httpx.Client(timeout=httpx.Timeout(self.timeout, connect=self.timeout, read=self.timeout, write=self.timeout))
 
     def chat(self, prompt, temperature=None, max_tokens=None, repetition_penalty=None, stream=False):

--- a/llm_utils/interfacing/mock_llm_client.py
+++ b/llm_utils/interfacing/mock_llm_client.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .base_client import BaseLLMClient
+from .llm_request import LLMError
+
+
+class LLMRequestMismatchError(LLMError):
+    """Raised when no mock response matches the given request."""
+
+
+class MockLLMClient(BaseLLMClient):
+    """LLM client that returns predefined responses for testing."""
+
+    def __init__(self, data: list[dict] | str | Path, **kwargs):
+        """Initialize the mock client.
+
+        Parameters
+        ----------
+        data: list[dict] | str | Path
+            Either a list of response records or path to a JSON file containing
+            such a list. Each record must include ``response`` and all request
+            fields used for lookup (e.g. ``model``, ``system_prompt``,
+            ``user_prompt``/``prompt``, ``temperature``, etc.).
+        kwargs: any
+            Additional parameters forwarded to :class:`BaseLLMClient`.
+        """
+        super().__init__(**kwargs)
+
+        if isinstance(data, (str, Path)):
+            records = json.loads(Path(data).read_text())
+        else:
+            records = data
+
+        self._lookup: dict[str, str] = {}
+        for rec in records:
+            key = self._make_key(
+                prompt=rec.get("user_prompt") or rec.get("prompt"),
+                temperature=rec.get("temperature"),
+                max_tokens=rec.get("max_tokens"),
+                repetition_penalty=rec.get("repetition_penalty"),
+                model=rec.get("model"),
+                system_prompt=rec.get("system_prompt"),
+            )
+            self._lookup[key] = rec["response"]
+
+    def _make_key(self, prompt: str, temperature, max_tokens, repetition_penalty, model=None, system_prompt=None) -> str:
+        data = {
+            "model": model if model is not None else self.model,
+            "system_prompt": system_prompt if system_prompt is not None else self.system_prompt,
+            "prompt": prompt,
+            "temperature": temperature if temperature is not None else self.temperature,
+            "max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
+            "repetition_penalty": repetition_penalty if repetition_penalty is not None else self.repetition_penalty,
+        }
+        return json.dumps(data, sort_keys=True)
+
+    def chat(self, prompt: str, temperature=None, max_tokens=None, repetition_penalty=None, stream: bool = False) -> str:
+        if stream:
+            raise NotImplementedError("Streaming is not supported in MockLLMClient.")
+
+        key = self._make_key(prompt, temperature, max_tokens, repetition_penalty)
+        try:
+            return self._lookup[key]
+        except KeyError:
+            raise LLMRequestMismatchError(f"No mock response for request: {key}")

--- a/tests/interfacing/test_mock_llm_client.py
+++ b/tests/interfacing/test_mock_llm_client.py
@@ -1,0 +1,36 @@
+import json
+import pytest
+from llm_utils.interfacing.mock_llm_client import MockLLMClient, LLMRequestMismatchError
+
+
+def make_record(prompt: str, response: str, model: str = "qwen:14b", system_prompt: str = "You are a helpful and concise assistant.", temperature: float = 0.7, max_tokens: int = 1024, repetition_penalty: float = 1.1):
+    return {
+        "model": model,
+        "system_prompt": system_prompt,
+        "user_prompt": prompt,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "repetition_penalty": repetition_penalty,
+        "response": response,
+    }
+
+
+def test_match_from_data():
+    data = [make_record("Tell me a joke", "Mocked joke")]
+    client = MockLLMClient(data, model="qwen:14b")
+    assert client.chat("Tell me a joke") == "Mocked joke"
+
+
+def test_match_from_file(tmp_path):
+    data = [make_record("Ping", "Pong")]
+    p = tmp_path / "mocks.json"
+    p.write_text(json.dumps(data))
+    client = MockLLMClient(str(p), model="qwen:14b")
+    assert client.chat("Ping") == "Pong"
+
+
+def test_unmatched_request_raises():
+    data = [make_record("A", "B")]
+    client = MockLLMClient(data, model="qwen:14b")
+    with pytest.raises(LLMRequestMismatchError):
+        client.chat("Something else")


### PR DESCRIPTION
## Summary
- add `BaseLLMClient` abstract base
- make `LLMClient` subclass `BaseLLMClient`
- implement `MockLLMClient` for deterministic testing
- document mock client usage in README
- expose new classes via package __init__
- add tests for `MockLLMClient`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ddfafa4f8833197a7aee7f35fa777