### PR TITLE
Add MockLLMClient for deterministic testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # llm-utils
 Training and interface scripts for llms that are general purpose
+
+## MockLLMClient
+
+`MockLLMClient` is a lightweight implementation of `BaseLLMClient` useful for unit tests. It loads predefined
+responses either from a list of dictionaries or from a JSON file. Each entry describes the request and the
+expected response.
+
+Example JSON structure:
+
+```json
+[
+  {
+    "model": "test-model",
+    "system": "Assistant",
+    "prompt": "Hello",
+    "temperature": 0.0,
+    "response": "Hi there"
+  }
+]
+```
+
+Usage:
+
+```python
+from llm_utils.interfacing.mock_client import MockLLMClient
+
+responses = [
+    {
+        "model": "test-model",
+        "system": "Assistant",
+        "prompt": "Hello",
+        "temperature": 0.0,
+        "response": "Hi there"
+    }
+]
+
+client = MockLLMClient(responses, model_name="test-model")
+text = client.generate("Hello", system="Assistant")
+print(text)  # "Hi there"
+```

--- a/llm_utils/interfacing/mock_client.py
+++ b/llm_utils/interfacing/mock_client.py
@@ -1,0 +1,57 @@
+import json
+from typing import Iterable, Mapping, Tuple, Union, List, Dict
+
+from .base_client import BaseLLMClient, LLMError
+
+
+class MockLLMClient(BaseLLMClient):
+    """A simple mock client that returns predefined responses.
+
+    Responses can be provided as a path to a JSON file or as a list of
+    dictionaries. Each dictionary should contain at least ``prompt`` and
+    ``response`` keys. ``model``, ``system`` and ``temperature`` default to the
+    values supplied when calling :meth:`generate` or during initialisation.
+
+    Example JSON structure::
+
+        [
+            {
+                "model": "dummy",
+                "system": "You are helpful",
+                "prompt": "Hello",
+                "temperature": 0.0,
+                "response": "Hi there"
+            }
+        ]
+    """
+
+    def __init__(
+        self,
+        responses: Union[str, Iterable[Mapping[str, Union[str, float]]]],
+        model_name: str | None = None,
+    ) -> None:
+        super().__init__(model_name)
+        if isinstance(responses, str):
+            with open(responses, "r", encoding="utf-8") as fh:
+                responses = json.load(fh)
+        self._responses: Dict[Tuple[str, str, str, float], str] = {}
+        for entry in responses:  # type: ignore[assignment]
+            model = entry.get("model", self.model_name)
+            system = entry.get("system", "")
+            prompt = entry.get("prompt")
+            temperature = float(entry.get("temperature", 0.0))
+            response = entry.get("response")
+            if prompt is None or response is None:
+                raise ValueError("Each entry must include 'prompt' and 'response'")
+            key = self._make_key(model, system, prompt, temperature)
+            self._responses[key] = response
+
+    @staticmethod
+    def _make_key(model: str, system: str, prompt: str, temperature: float) -> Tuple[str, str, str, float]:
+        return model, system, prompt, temperature
+
+    def generate(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+        key = self._make_key(self.model_name, system, prompt, temperature)
+        if key not in self._responses:
+            raise LLMError(f"No mock response for request: {key}")
+        return self._responses[key]

--- a/tests/interfacing/test_mock_client.py
+++ b/tests/interfacing/test_mock_client.py
@@ -1,0 +1,34 @@
+import json
+import pytest
+from llm_utils.interfacing.mock_client import MockLLMClient
+from llm_utils.interfacing.base_client import LLMError
+
+
+def test_generate_from_list():
+    responses = [
+        {
+            "model": "m1",
+            "system": "sys",
+            "prompt": "hi",
+            "temperature": 0.0,
+            "response": "hello"
+        }
+    ]
+    client = MockLLMClient(responses, model_name="m1")
+    assert client.generate("hi", system="sys", temperature=0.0) == "hello"
+
+
+def test_generate_from_file(tmp_path):
+    data = [
+        {"model": "m2", "system": "", "prompt": "ping", "temperature": 0.5, "response": "pong"}
+    ]
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps(data))
+    client = MockLLMClient(str(path), model_name="m2")
+    assert client.generate("ping", temperature=0.5) == "pong"
+
+
+def test_unmatched_request_raises():
+    client = MockLLMClient([], model_name="none")
+    with pytest.raises(LLMError):
+        client.generate("something")


### PR DESCRIPTION
## Summary
- add `MockLLMClient` implementing `BaseLLMClient`
- document mock client in README
- test the mock client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686debd8341c8331bd9b50ade5e57226