### PR TITLE
Rename LLMClient class

### DIFF
--- a/llm_utils/interfacing/llm_request.py
+++ b/llm_utils/interfacing/llm_request.py
@@ -25,7 +25,7 @@ class LLMUnexpectedResponseError(LLMError):
 DEFAULT_MODEL = os.getenv("LLM_MODEL", "qwen:14b")
 DEFAULT_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:1234/v1")
 
-class LLMClient:
+class OpenAILikeLLMClient:
     def __init__(self, model=None, base_url=None, timeout=60, system_prompt=None, temperature=0.7, max_tokens=1024, repetition_penalty=1.1, client=None):
         self.model = model or os.getenv("LLM_MODEL", "qwen:14b")
         self.base_url = base_url or os.getenv("LLM_BASE_URL", "http://localhost:1234/v1")
@@ -34,7 +34,12 @@ class LLMClient:
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.repetition_penalty = repetition_penalty
-        self.client = client or httpx.Client(timeout=httpx.Timeout(self.timeout, connect=self.timeout, read=self.timeout, write=self.timeout))
+
+        self.client = client or httpx.Client(
+            timeout=httpx.Timeout(
+                self.timeout, connect=self.timeout, read=self.timeout, write=self.timeout
+            )
+        )
 
     def chat(self, prompt, temperature=None, max_tokens=None, repetition_penalty=None, stream=False):
         if stream:
@@ -90,6 +95,10 @@ class LLMClient:
     def __del__(self):
         if hasattr(self, "client"):
             self.client.close()
+
+# Backwards compatibility: allow older imports that expect `LLMClient`
+LLMClient = OpenAILikeLLMClient
+
 def main():
     import argparse
 
@@ -104,7 +113,7 @@ def main():
 
     args = parser.parse_args()
 
-    client = LLMClient(
+    client = OpenAILikeLLMClient(
         model=args.model,
         base_url=args.base_url,
         temperature=args.temperature,
@@ -116,5 +125,4 @@ def main():
     response = client.chat(args.prompt)
     print(response)
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    main()

--- a/tests/interfacing/test_llm_request.py
+++ b/tests/interfacing/test_llm_request.py
@@ -3,7 +3,7 @@ import httpx
 import json
 import pytest
 import os
-from llm_utils.interfacing.llm_request import LLMClient
+from llm_utils.interfacing.llm_request import OpenAILikeLLMClient
 from llm_utils.interfacing.llm_request import (
     LLMTimeoutError,
     LLMConnectionError,
@@ -27,7 +27,7 @@ class TestLLMClient:
 
     def test_default_values(self, monkeypatch):
         transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "mock"}}]}))
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
         assert client.system_prompt == "You are a helpful and concise assistant."
         assert client.model == "qwen:14b"
         assert client.base_url == "http://localhost:1234/v1"
@@ -39,7 +39,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "mock"}}]}))
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         assert client.system_prompt == "Test prompt."
         assert client.model == "test-model"
@@ -52,7 +52,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "mock"}}]}))
 
-        client = LLMClient(
+        client = OpenAILikeLLMClient(
             system_prompt="Manual prompt.",
             model="manual-model",
             base_url="http://manual-server",
@@ -76,7 +76,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(handler)
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         prompt_text = "Tell me a joke."
         result = client.chat(prompt_text)
@@ -97,7 +97,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(timeout_handler)
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         with pytest.raises(LLMTimeoutError):
             client.chat("Trigger timeout")
@@ -108,7 +108,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(broken_handler)
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         with pytest.raises(LLMConnectionError):
             client.chat("Trigger connection error")
@@ -122,7 +122,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(model_not_found_handler)
 
-        client = LLMClient(model="gibberish-model-name", client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(model="gibberish-model-name", client=httpx.Client(transport=transport))
 
         with pytest.raises(LLMModelNotFoundError):
             client.chat("Test with missing model")
@@ -136,7 +136,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(access_denied_handler)
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         with pytest.raises(LLMAccessDeniedError):
             client.chat("Trigger access denied")
@@ -150,7 +150,7 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(invalid_request_handler)
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         with pytest.raises(LLMInvalidRequestError):
             client.chat("Trigger invalid request")
@@ -164,9 +164,8 @@ class TestLLMClient:
 
         transport = httpx.MockTransport(server_error_handler)
 
-        client = LLMClient(client=httpx.Client(transport=transport))
+        client = OpenAILikeLLMClient(client=httpx.Client(transport=transport))
 
         with pytest.raises(LLMUnexpectedResponseError) as exc_info:
             client.chat("Trigger internal server error")
-
         assert "Internal Server Error" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- rename `LLMClient` to `OpenAILikeLLMClient`
- expose `LLMClient` alias for backward compatibility
- update tests to import the new class

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0a2041bc8331992a15dff97488a3