### PR TITLE
Refactor dataset loading helper

### DIFF
--- a/llm_utils/data/dataset_loading.py
+++ b/llm_utils/data/dataset_loading.py
@@ -1,0 +1,16 @@
+import os
+from datasets import load_dataset, Dataset, DatasetDict
+
+def load_dataset_auto(path: str, split: str = "train"):
+    """Load a dataset from a local path or HF hub."""
+    if path.startswith("hf:"):
+        ds = load_dataset(path[3:])
+        return ds[split] if isinstance(ds, DatasetDict) else ds
+    ext = os.path.splitext(path)[1].lower()
+    if ext in {".json", ".jsonl"}:
+        return load_dataset("json", data_files=path, split=split)
+    if ext == ".csv":
+        return load_dataset("csv", data_files=path, split=split)
+    if os.path.isdir(path):
+        return Dataset.load_from_disk(path)
+    raise ValueError(f"Unsupported dataset path: {path}")

--- a/llm_utils/inference/run_bert.py
+++ b/llm_utils/inference/run_bert.py
@@ -7,7 +7,7 @@ import numpy as np
 from transformers import BertForSequenceClassification
 from transformers import AutoTokenizer  # Not BertTokenizer
 from sklearn.preprocessing import LabelEncoder
-from datasets import load_dataset, Dataset
+from llm_utils.data.dataset_loading import load_dataset_auto
 from typing import cast, Any, Tuple
 from sklearn.metrics import classification_report
 from tqdm import tqdm
@@ -132,8 +132,7 @@ def run_repl(model, tokenizer, label_encoder, device, min_confidence=None, model
             break
 
 def evaluate_bulk(data_path, model, tokenizer, label_encoder, device, text_field="text", label_field="label", min_confidence=None, detail=False, model_type="sequence", is_binary_sigmoid=False):
-    dataset_obj = load_dataset("json", data_files=data_path)
-    dataset = dataset_obj["train"] if isinstance(dataset_obj, dict) and "train" in dataset_obj else dataset_obj
+    dataset = load_dataset_auto(data_path)
     if not isinstance(dataset, Dataset):
         raise TypeError("Loaded dataset is not a regular Dataset; check if streaming mode or a different format was used.")
     y_true = []

--- a/llm_utils/inference/run_t5.py
+++ b/llm_utils/inference/run_t5.py
@@ -6,7 +6,7 @@ import atexit
 import torch
 
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
-from datasets import load_dataset, Dataset
+from llm_utils.data.dataset_loading import load_dataset_auto
 from sklearn.metrics import precision_recall_fscore_support
 
 def load_model_and_tokenizer(model_path):
@@ -37,7 +37,7 @@ def generate_single(text, model, tokenizer, max_new_tokens=64, num_beams=1, max_
     return tokenizer.decode(output_ids[0], skip_special_tokens=True)
 
 def evaluate_bulk(dataset_path, model, tokenizer, text_field="input", target_field="output", max_new_tokens=64, num_beams=1, show_detail=False, max_input_length=4096):
-    ds = load_dataset("json", data_files=dataset_path)["train"]
+    ds = load_dataset_auto(dataset_path)
 
     predictions = []
     references = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,10 @@ training = [
     "pynvml",
     "urllib3",
     "safetensors",
-    "tensorboard"
+    "tensorboard",
+    "evaluate",
+    "psutil",
+    "accelerate"
 ]
 test = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-utils"
-version = "0.8.4"
+version = "0.8.5"
 description = "Lightweight utilities for LLM data parsing and training"
 authors = [
     { name="Mitchell Currie" }

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -1,0 +1,32 @@
+import importlib
+import types
+import sys
+
+
+def make_mod(monkeypatch):
+    dummy_ds = types.SimpleNamespace(from_dict=lambda d: d,
+                                     load_from_disk=lambda p: f"disk:{p}")
+    def fake_load_dataset(fmt, data_files=None, split='train'):
+        return f"{fmt}:{data_files}:{split}"
+    datasets_mod = types.SimpleNamespace(load_dataset=fake_load_dataset,
+                                         Dataset=dummy_ds,
+                                         DatasetDict=dict)
+    monkeypatch.setitem(sys.modules, 'datasets', datasets_mod)
+    return importlib.reload(importlib.import_module('llm_utils.data.dataset_loading'))
+
+
+def test_load_json(monkeypatch):
+    mod = make_mod(monkeypatch)
+    assert mod.load_dataset_auto('data.jsonl') == 'json:data.jsonl:train'
+
+
+def test_load_csv(monkeypatch):
+    mod = make_mod(monkeypatch)
+    assert mod.load_dataset_auto('file.csv') == 'csv:file.csv:train'
+
+
+def test_load_disk(monkeypatch, tmp_path):
+    mod = make_mod(monkeypatch)
+    d = tmp_path / 'ds'
+    d.mkdir()
+    assert mod.load_dataset_auto(str(d)) == f'disk:{d}'


### PR DESCRIPTION
## Summary
- add `load_dataset_auto` utility to load local or HF datasets
- update training and inference scripts to use new helper
- adjust dataset split logic for zero-validation case
- expand tests for new helper and update existing stubs
- bump version to 0.8.5

## Testing
- `pytest tests/test_dataset_loading.py tests/training/test_train_t5.py tests/training/test_train_t5_trainer_integration.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687646f3eedc83319255a5133d337fa5