### PR TITLE
Support image inputs in LLM clients

### DIFF
--- a/llm_utils/interfacing/base_client.py
+++ b/llm_utils/interfacing/base_client.py
@@ -17,7 +17,7 @@ class BaseLLMClient(ABC):
         self.system_prompt = system_prompt or "You are a helpful assistant."
 
     @abstractmethod
-    def generate(self, prompt, system="", temperature=0.0) -> str:
+    def generate(self, prompt, system="", temperature=0.0, images=None) -> str:
         """
         Generate a response from the language model.
 
@@ -25,6 +25,8 @@ class BaseLLMClient(ABC):
             prompt (str): The prompt text.
             system (str, optional): System message or instruction. Defaults to "".
             temperature (float, optional): Sampling temperature. Defaults to 0.0.
+            images (list[str] | None, optional): List of base64 encoded images to
+                include with the prompt. Defaults to None.
 
         Returns:
             str: The generated response.

--- a/llm_utils/interfacing/google_genai_client.py
+++ b/llm_utils/interfacing/google_genai_client.py
@@ -30,7 +30,7 @@ class GoogleLLMClient(BaseLLMClient):
         self.timeout = timeout
         self.max_output_tokens = max_output_tokens
 
-    def generate(self, prompt, system="", temperature=0.0) -> str:
+    def generate(self, prompt, system="", temperature=0.0, images=None) -> str:
         if not prompt or len(prompt) == 0:
             raise ValueError("Prompt must not be empty for GoogleLLMClient.")
         if not self.model:
@@ -54,8 +54,15 @@ class GoogleLLMClient(BaseLLMClient):
                 HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
             }
 
+            contents = [prompt]
+            if images:
+                for img in images:
+                    contents.append({
+                        "inline_data": {"mime_type": "image/png", "data": img}
+                    })
+
             response = model_instance.generate_content(
-                contents=prompt,
+                contents=contents,
                 generation_config=generation_config,
                 safety_settings=safety_settings,
             )

--- a/llm_utils/interfacing/llm_request.py
+++ b/llm_utils/interfacing/llm_request.py
@@ -40,7 +40,7 @@ class OpenAILikeLLMClient(BaseLLMClient):
         )
 
     # This just wraps the original chat method to match the new interface
-    def generate(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+    def generate(self, prompt: str, system: str = "", temperature: float = 0.0, images=None) -> str:
         if system:
             self.system_prompt = system.strip()
         
@@ -49,21 +49,33 @@ class OpenAILikeLLMClient(BaseLLMClient):
             temperature=temperature if temperature is not None else self.temperature,
             max_tokens=self.max_tokens,
             repetition_penalty=self.repetition_penalty,
-            stream=False
+            stream=False,
+            images=images,
         )
         return response
     
     # Holdover from the original interface
-    def chat(self, prompt, temperature=None, max_tokens=None, repetition_penalty=None, stream=False):
+    def chat(self, prompt, temperature=None, max_tokens=None, repetition_penalty=None, stream=False, images=None):
         if stream:
             raise NotImplementedError("Streaming is not supported yet.")
-        
+
+        messages = [
+            {"role": "system", "content": self.system_prompt.strip()}
+        ]
+        if images:
+            content = [{"type": "text", "text": prompt}]
+            for img in images:
+                content.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{img}"}
+                })
+            messages.append({"role": "user", "content": content})
+        else:
+            messages.append({"role": "user", "content": prompt})
+
         payload = {
             "model": self.model,
-            "messages": [
-                {"role": "system", "content": self.system_prompt.strip()},
-                {"role": "user", "content": prompt}
-            ],
+            "messages": messages,
             "temperature": temperature if temperature is not None else self.temperature,
             "max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
             "repetition_penalty": repetition_penalty if repetition_penalty is not None else self.repetition_penalty,

--- a/llm_utils/interfacing/mock_client.py
+++ b/llm_utils/interfacing/mock_client.py
@@ -52,9 +52,9 @@ class MockLLMClient(BaseLLMClient):
     def _make_key(model: str, system: str, prompt: str, temperature: float) -> Tuple[str, str, str, float]:
         return model, system, prompt, temperature
 
-    def generate(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+    def generate(self, prompt: str, system: str = "", temperature: float = 0.0, images=None) -> str:
         if self._on_request:
-            override = self._on_request(prompt=prompt, system=system, temperature=temperature)
+            override = self._on_request(prompt=prompt, system=system, temperature=temperature, images=images)
             if override is not None:
                 return override
         key = self._make_key(self.model, system, prompt, temperature)
@@ -62,8 +62,8 @@ class MockLLMClient(BaseLLMClient):
             raise LLMError(f"No mock response for request: {key}")
         return self._responses[key]
 
-    def prompt(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+    def prompt(self, prompt: str, system: str = "", temperature: float = 0.0, images=None) -> str:
         """
         Alias for generate, plus supports callback override.
         """
-        return self.generate(prompt, system=system, temperature=temperature)
+        return self.generate(prompt, system=system, temperature=temperature, images=images)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-utils"
-version = "0.8.5"
+version = "0.8.6"
 description = "Lightweight utilities for LLM data parsing and training"
 authors = [
     { name="Mitchell Currie" }

--- a/tests/interfacing/test_mock_client.py
+++ b/tests/interfacing/test_mock_client.py
@@ -32,3 +32,12 @@ def test_unmatched_request_raises():
     client = MockLLMClient([], model_name="none")
     with pytest.raises(LLMError):
         client.generate("something")
+
+
+def test_generate_with_images_ignored():
+    responses = [
+        {"model": "m3", "system": "", "prompt": "image", "temperature": 0.0, "response": "ok"}
+    ]
+    client = MockLLMClient(responses, model_name="m3")
+    result = client.generate("image", images=["abcd"], system="", temperature=0.0)
+    assert result == "ok"


### PR DESCRIPTION
## Summary
- allow passing images to BaseLLMClient.generate
- handle multi-image prompts for OpenAI-compatible client
- support image parts in Google Generative AI client
- ignore images in MockLLMClient
- add tests for image support
- bump version to 0.8.6

## Testing
- `pip install -e .[training,test] evaluate` *(failed: ModuleNotFoundError: No module named 'httpx')*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68773063b1108331918b9922e7b1c200