### PR TITLE
Add multi-image support to LLM clients

### DIFF
--- a/llm_utils/interfacing/base_client.py
+++ b/llm_utils/interfacing/base_client.py
@@ -17,7 +17,7 @@ class BaseLLMClient(ABC):
         self.system_prompt = system_prompt or "You are a helpful assistant."
 
     @abstractmethod
-    def generate(self, prompt, system="", temperature=0.0) -> str:
+    def generate(self, prompt, system="", temperature=0.0, images=None) -> str:
         """
         Generate a response from the language model.
 
@@ -25,6 +25,8 @@ class BaseLLMClient(ABC):
             prompt (str): The prompt text.
             system (str, optional): System message or instruction. Defaults to "".
             temperature (float, optional): Sampling temperature. Defaults to 0.0.
+            images (list[str] | None, optional): Base64 encoded images to send
+                with the prompt. Defaults to None.
 
         Returns:
             str: The generated response.

--- a/llm_utils/interfacing/google_genai_client.py
+++ b/llm_utils/interfacing/google_genai_client.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import base64
 from llm_utils.interfacing.base_client import BaseLLMClient
 
 try:
@@ -30,7 +31,7 @@ class GoogleLLMClient(BaseLLMClient):
         self.timeout = timeout
         self.max_output_tokens = max_output_tokens
 
-    def generate(self, prompt, system="", temperature=0.0) -> str:
+    def generate(self, prompt, system="", temperature=0.0, images=None) -> str:
         if not prompt or len(prompt) == 0:
             raise ValueError("Prompt must not be empty for GoogleLLMClient.")
         if not self.model:
@@ -54,8 +55,20 @@ class GoogleLLMClient(BaseLLMClient):
                 HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
             }
 
+            contents = [prompt]
+            if images:
+                for img in images:
+                    contents.append(
+                        {
+                            "inline_data": {
+                                "mime_type": "image/png",
+                                "data": base64.b64decode(img),
+                            }
+                        }
+                    )
+
             response = model_instance.generate_content(
-                contents=prompt,
+                contents=contents,
                 generation_config=generation_config,
                 safety_settings=safety_settings,
             )

--- a/llm_utils/interfacing/mock_client.py
+++ b/llm_utils/interfacing/mock_client.py
@@ -52,7 +52,7 @@ class MockLLMClient(BaseLLMClient):
     def _make_key(model: str, system: str, prompt: str, temperature: float) -> Tuple[str, str, str, float]:
         return model, system, prompt, temperature
 
-    def generate(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+    def generate(self, prompt: str, system: str = "", temperature: float = 0.0, images: List[str] | None = None) -> str:
         if self._on_request:
             override = self._on_request(prompt=prompt, system=system, temperature=temperature)
             if override is not None:
@@ -62,8 +62,8 @@ class MockLLMClient(BaseLLMClient):
             raise LLMError(f"No mock response for request: {key}")
         return self._responses[key]
 
-    def prompt(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+    def prompt(self, prompt: str, system: str = "", temperature: float = 0.0, images: List[str] | None = None) -> str:
         """
         Alias for generate, plus supports callback override.
         """
-        return self.generate(prompt, system=system, temperature=temperature)
+        return self.generate(prompt, system=system, temperature=temperature, images=images)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-utils"
-version = "0.8.5"
+version = "0.8.6"
 description = "Lightweight utilities for LLM data parsing and training"
 authors = [
     { name="Mitchell Currie" }


### PR DESCRIPTION
## Summary
- allow `BaseLLMClient.generate` to accept images
- support multi-image prompts in `OpenAILikeLLMClient`
- add inline image support to `GoogleLLMClient`
- ignore images in `MockLLMClient`
- test image payload handling
- bump version to 0.8.6

## Testing
- `pip install -e .[training,test] > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pip install evaluate >> /tmp/pip.log && tail -n 5 /tmp/pip.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773063b1108331918b9922e7b1c200