### PR TITLE
Consolidate evaluation helpers

### DIFF
--- a/llm_utils/training/evaluation_utils.py
+++ b/llm_utils/training/evaluation_utils.py
@@ -1,10 +1,5 @@
-import logging
-from transformers import TrainerCallback
+"""Evaluation utilities shared across training scripts."""
 
-logger = logging.getLogger(__name__)
+from .utils import calculate_dynamic_eval_steps
 
-# training/utils.py
-def calculate_dynamic_eval_steps(train_dataset_size: int, batch_size: int, preferred_fraction: float = 1/3, max_steps: int = 10000) -> int:
-    steps_per_epoch = train_dataset_size // batch_size
-    proposed_steps = int(steps_per_epoch * preferred_fraction)
-    return min(steps_per_epoch, max(proposed_steps, 1), max_steps)
+__all__ = ["calculate_dynamic_eval_steps"]

--- a/llm_utils/training/train_bert.py
+++ b/llm_utils/training/train_bert.py
@@ -17,8 +17,11 @@ from transformers import TrainerCallback
 from transformers import EarlyStoppingCallback
 from torch.utils.tensorboard import SummaryWriter
 from .callbacks import EpochNormalizedLogger, MemoryUsageLogger, ManualEarlyStopCallback
-from .evaluation_utils import calculate_dynamic_eval_steps
-from .utils import load_and_filter_dataframe, determine_batch_size
+from .utils import (
+    load_and_filter_dataframe,
+    determine_batch_size,
+    calculate_dynamic_eval_steps,
+)
 import warnings
 from transformers import logging as hf_logging
 import copy

--- a/llm_utils/training/utils.py
+++ b/llm_utils/training/utils.py
@@ -81,3 +81,19 @@ def determine_batch_size(model_checkpoint: str, no_batching: bool, total_vram_gb
         # do not exceed base_batch for large hidden sizes
         batch_size = min(batch_size, base_batch)
     return max(1, batch_size)
+
+
+def calculate_dynamic_eval_steps(
+    train_dataset_size: int,
+    batch_size: int,
+    preferred_fraction: float = 1 / 3,
+    max_steps: int = 10000,
+) -> int:
+    """Return evaluation interval based on dataset size and batch size.
+
+    This helper is shared by multiple training scripts to keep evaluation
+    frequency consistent across models.
+    """
+    steps_per_epoch = train_dataset_size // batch_size
+    proposed_steps = int(steps_per_epoch * preferred_fraction)
+    return min(steps_per_epoch, max(proposed_steps, 1), max_steps)

--- a/tests/training/test_evaluation_utils.py
+++ b/tests/training/test_evaluation_utils.py
@@ -1,0 +1,5 @@
+import importlib
+
+def test_dynamic_steps_basic():
+    utils = importlib.import_module('llm_utils.training.utils')
+    assert utils.calculate_dynamic_eval_steps(1000, 32) == 10


### PR DESCRIPTION
## Summary
- move `calculate_dynamic_eval_steps` into `training/utils`
- re-export function from `evaluation_utils`
- update BERT training script to import from utils
- add regression test for dynamic step calculation

## Testing
- `pip install -e .[training,test]`
- `pip install evaluate`
- `pip install google-generativeai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aa982b00833193f143d60643cacb