### PR TITLE
Make image args optional

### DIFF
--- a/llm_utils/interfacing/base_client.py
+++ b/llm_utils/interfacing/base_client.py
@@ -17,7 +17,13 @@ class BaseLLMClient(ABC):
         self.system_prompt = system_prompt or "You are a helpful assistant."
 
     @abstractmethod
-    def generate(self, prompt, system="", temperature=0.0, images=None) -> str:
+    def generate(
+        self,
+        prompt: str,
+        system: str = "",
+        temperature: float = 0.0,
+        images: list[str] | None = None,
+    ) -> str:
         """
         Generate a response from the language model.
 

--- a/llm_utils/interfacing/google_genai_client.py
+++ b/llm_utils/interfacing/google_genai_client.py
@@ -31,7 +31,13 @@ class GoogleLLMClient(BaseLLMClient):
         self.timeout = timeout
         self.max_output_tokens = max_output_tokens
 
-    def generate(self, prompt, system="", temperature=0.0, images=None) -> str:
+    def generate(
+        self,
+        prompt: str,
+        system: str = "",
+        temperature: float = 0.0,
+        images: list[str] | None = None,
+    ) -> str:
         if not prompt or len(prompt) == 0:
             raise ValueError("Prompt must not be empty for GoogleLLMClient.")
         if not self.model:

--- a/llm_utils/interfacing/llm_request.py
+++ b/llm_utils/interfacing/llm_request.py
@@ -40,7 +40,13 @@ class OpenAILikeLLMClient(BaseLLMClient):
         )
 
     # This just wraps the original chat method to match the new interface
-    def generate(self, prompt: str, system: str = "", temperature: float = 0.0, images=None) -> str:
+    def generate(
+        self,
+        prompt: str,
+        system: str = "",
+        temperature: float = 0.0,
+        images: list[str] | None = None,
+    ) -> str:
         if system:
             self.system_prompt = system.strip()
         
@@ -55,7 +61,15 @@ class OpenAILikeLLMClient(BaseLLMClient):
         return response
     
     # Holdover from the original interface
-    def chat(self, prompt, temperature=None, max_tokens=None, repetition_penalty=None, stream=False, images=None):
+    def chat(
+        self,
+        prompt: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        repetition_penalty: float | None = None,
+        stream: bool = False,
+        images: list[str] | None = None,
+    ):
         if stream:
             raise NotImplementedError("Streaming is not supported yet.")
         

--- a/llm_utils/interfacing/mock_client.py
+++ b/llm_utils/interfacing/mock_client.py
@@ -52,7 +52,13 @@ class MockLLMClient(BaseLLMClient):
     def _make_key(model: str, system: str, prompt: str, temperature: float) -> Tuple[str, str, str, float]:
         return model, system, prompt, temperature
 
-    def generate(self, prompt: str, system: str = "", temperature: float = 0.0, images=None) -> str:
+    def generate(
+        self,
+        prompt: str,
+        system: str = "",
+        temperature: float = 0.0,
+        images: list[str] | None = None,
+    ) -> str:
         if self._on_request:
             override = self._on_request(prompt=prompt, system=system, temperature=temperature, images=images)
             if override is not None:
@@ -62,7 +68,13 @@ class MockLLMClient(BaseLLMClient):
             raise LLMError(f"No mock response for request: {key}")
         return self._responses[key]
 
-    def prompt(self, prompt: str, system: str = "", temperature: float = 0.0, images=None) -> str:
+    def prompt(
+        self,
+        prompt: str,
+        system: str = "",
+        temperature: float = 0.0,
+        images: list[str] | None = None,
+    ) -> str:
         """
         Alias for generate, plus supports callback override.
         """


### PR DESCRIPTION
## Summary
- allow optional images for all LLM clients
- run tests

## Testing
- `pip install -e .[training,test]`
- `pip install evaluate`
- `pip install google-generativeai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68784ad11ccc8331969ca0bee971c91a